### PR TITLE
Fix transaction status tool name

### DIFF
--- a/src/tools/transactions/index.ts
+++ b/src/tools/transactions/index.ts
@@ -13,7 +13,7 @@ export {
 // Define tool metadata (optional, but good practice)
 export const toolMetadata = {
   getTransactionStatus: {
-    name: 'transactions_getStatus', // Consistent naming with other tools
+    name: 'transactions_getTransactionStatus', // Consistent naming with other tools
     description: 'Get the status and details of a blockchain transaction by its hash.',
     example: 'Get status for transaction 0x...',
   },


### PR DESCRIPTION
## Summary
- fix metadata name for getTransactionStatus

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f69e0b7f0832296bdd8b05517d9b7