### PR TITLE
Bump version to 0.4.3 and pin npm to 11.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Linea MCP project will be documented in this file.
 
+## [0.4.3]
+
+### Changed
+- Bumped package version to 0.4.3 for the latest release.
+- Pinned the project to npm 11.7.0 via the package manager metadata.
+
 ## [0.4.2]
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linea-mcp",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linea-mcp",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linea-mcp",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A Model Context Protocol server for interacting with the Linea blockchain",
   "type": "module",
   "main": "dist/index.js",
@@ -39,6 +39,7 @@
     "type": "git",
     "url": "https://github.com/qvkare/linea-mcp.git"
   },
+  "packageManager": "npm@11.7.0",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",
     "axios": "^1.13.2",


### PR DESCRIPTION
### Motivation
- Prepare a new release by updating the package version to `0.4.3` and record the release in the changelog.
- Ensure consistent developer/install environment by pinning the npm client via `packageManager` metadata to `npm@11.7.0`.

### Description
- Updated `version` from `0.4.2` to `0.4.3` in `package.json` and synchronized the version in `package-lock.json`.
- Added `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968a97b2e7c8322873ca1863520aaee)